### PR TITLE
[website] add config container and use repo images

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -62,9 +62,9 @@
 <footer class="bg-gray-800 text-gray-300 py-8" data-reveal>
   <div class="container mx-auto px-4 text-center space-y-4">
     <div>
-      <a href="#" class="mx-2 text-accent">Twitter</a>
-      <a href="#" class="mx-2 text-accent">Discord</a>
-      <a href="#" class="mx-2 text-accent">YouTube</a>
+      <a href="#" class="mx-2 text-accent" data-link="twitter">Twitter</a>
+      <a href="#" class="mx-2 text-accent" data-link="discord">Discord</a>
+      <a href="#" class="mx-2 text-accent" data-link="youtube">YouTube</a>
     </div>
     <form class="flex flex-col sm:flex-row justify-center gap-2">
       <input type="email" placeholder="Join our newsletter" class="px-4 py-2 rounded-full text-black" required>

--- a/site/screenshots.html
+++ b/site/screenshots.html
@@ -41,6 +41,13 @@
     <img src="/static/images/Screenshot 2025-02-02 150239.png" alt="Screenshot" class="rounded-lg shadow" loading="lazy" data-type="pixel">
     <img src="/static/images/Screenshot 2025-02-04 002826.png" alt="Screenshot" class="rounded-lg shadow" loading="lazy" data-type="concept">
     <img src="/static/images/Screenshot 2025-02-04 002858.png" alt="Screenshot" class="rounded-lg shadow" loading="lazy" data-type="ui">
+    <img src="/static/images/Screenshot 2025-02-04 003122.png" alt="Screenshot" class="rounded-lg shadow" loading="lazy" data-type="pixel">
+    <img src="/static/images/Screenshot 2025-02-04 230529.png" alt="Screenshot" class="rounded-lg shadow" loading="lazy" data-type="concept">
+    <img src="/static/images/Screenshot 2025-02-06 195539.png" alt="Screenshot" class="rounded-lg shadow" loading="lazy" data-type="ui">
+    <img src="/static/images/Screenshot 2025-02-06 195923.png" alt="Screenshot" class="rounded-lg shadow" loading="lazy" data-type="pixel">
+    <img src="/static/images/Screenshot 2025-02-28 015411.png" alt="Screenshot" class="rounded-lg shadow" loading="lazy" data-type="concept">
+    <img src="/static/images/Screenshot 2025-02-28 015447.png" alt="Screenshot" class="rounded-lg shadow" loading="lazy" data-type="ui">
+    <img src="/static/images/Screenshot 2025-03-27 195435.png" alt="Screenshot" class="rounded-lg shadow" loading="lazy" data-type="pixel">
   </div>
 </main>
 <footer class="bg-gray-800 text-gray-300 py-4 text-center" data-reveal>

--- a/site/script.js
+++ b/site/script.js
@@ -1,5 +1,22 @@
+/* Global configuration for site-wide values */
+const SITE_CONFIG = {
+  links: {
+    twitter: 'https://twitter.com/tentcity',
+    discord: 'https://discord.gg/tentcity',
+    youtube: 'https://youtube.com/tentcity'
+  }
+};
+
 /* Intersection Observer for scroll reveal */
 document.addEventListener('DOMContentLoaded', () => {
+  // Replace any anchor with a data-link attribute using SITE_CONFIG values
+  document.querySelectorAll('[data-link]').forEach(el => {
+    const key = el.dataset.link;
+    if (SITE_CONFIG.links[key]) {
+      el.href = SITE_CONFIG.links[key];
+    }
+  });
+
   const revealEls = document.querySelectorAll('[data-reveal]');
   const obs = new IntersectionObserver((entries) => {
     entries.forEach(entry => {


### PR DESCRIPTION
## Summary
- add SITE_CONFIG container to store common link URLs
- update footer links to use data attributes
- display all unused images on the screenshots page

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6842ae3ed10c832b83a66e5789b1465a