### PR TITLE
[tentcity-website] Add environment variable loader

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and fill in your API keys
+SOME_API_KEY=your_api_key_here
+ANOTHER_API_SECRET=your_api_secret_here

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ CodeCoverage/
 *.VisualState.xml
 TestResult.xml
 nunit-*.xml
+# Environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ No build step is required as Tailwind is loaded via CDN.
 ## Node Scripts
 
 Run `pnpm test` to execute the placeholder test script.
+
+## Environment Variables
+
+Some scripts may rely on API keys or other secrets. Copy `.env.example` to `.env`
+and fill in your values. Use `require('./scripts/config').loadEnv()` in any Node
+script to populate `process.env` from this file.

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+function parseEnv(content) {
+  const result = {};
+  content.split(/\r?\n/).forEach(line => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) return;
+    const [key, ...rest] = trimmed.split('=');
+    result[key] = rest.join('=');
+  });
+  return result;
+}
+
+function loadEnv(envPath = path.resolve(__dirname, '..', '.env')) {
+  if (!fs.existsSync(envPath)) return {};
+  const file = fs.readFileSync(envPath, 'utf8');
+  const env = parseEnv(file);
+  Object.assign(process.env, env);
+  return env;
+}
+
+module.exports = {
+  loadEnv,
+};


### PR DESCRIPTION
## Summary
- add `.env.example` template
- ignore `.env` files
- document environment variable usage
- create `scripts/config.js` to load `.env`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6842b06c85b8832bb6fd8bf0db1b6400