### PR TITLE
[website] Add basic MongoDB login support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Copy this file to .env and fill in your API keys
 SOME_API_KEY=your_api_key_here
 ANOTHER_API_SECRET=your_api_secret_here
+MONGODB_URI=mongodb://localhost:27017/tentcity

--- a/README.md
+++ b/README.md
@@ -34,3 +34,16 @@ Run `pnpm test` to execute the placeholder test script.
 Some scripts may rely on API keys or other secrets. Copy `.env.example` to `.env`
 and fill in your values. Use `require('./scripts/config').loadEnv()` in any Node
 script to populate `process.env` from this file.
+
+### User Authentication Server
+
+A small Express server (`server.js`) handles account registration and login. It connects to MongoDB using the `MONGODB_URI` environment variable.
+
+Run the server with:
+
+```bash
+pnpm install
+pnpm start
+```
+
+The static site is served from the root path, so visit `/login.html` or `/signup.html` to test authentication.

--- a/package.json
+++ b/package.json
@@ -3,8 +3,14 @@
   "version": "1.0.0",
   "description": "Static website for TentCity Software",
   "scripts": {
-    "test": "echo \"No tests specified\""
+    "test": "echo \"No tests specified\"",
+    "start": "node server.js"
   },
   "private": true,
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.18.2",
+    "mongodb": "^5.7.0",
+    "bcryptjs": "^2.4.3"
+  }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,67 @@
+const path = require('path');
+const express = require('express');
+const { MongoClient } = require('mongodb');
+const bcrypt = require('bcryptjs');
+const { loadEnv } = require('./scripts/config');
+
+loadEnv();
+
+const uri = process.env.MONGODB_URI;
+if (!uri) {
+  console.error('MONGODB_URI not set');
+  process.exit(1);
+}
+
+const client = new MongoClient(uri);
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'site')));
+app.use('/static', express.static(path.join(__dirname, 'static')));
+
+let users;
+
+async function start() {
+  await client.connect();
+  const db = client.db();
+  users = db.collection('users');
+  app.listen(PORT, () => {
+    console.log(`Server running on http://localhost:${PORT}`);
+  });
+}
+
+app.post('/api/register', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  const existing = await users.findOne({ username });
+  if (existing) {
+    return res.status(409).json({ error: 'User exists' });
+  }
+  const hash = await bcrypt.hash(password, 10);
+  await users.insertOne({ username, password: hash });
+  res.json({ message: 'User created' });
+});
+
+app.post('/api/login', async (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) {
+    return res.status(400).json({ error: 'Missing fields' });
+  }
+  const user = await users.findOne({ username });
+  if (!user) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  const match = await bcrypt.compare(password, user.password);
+  if (!match) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  res.json({ message: 'Login successful' });
+});
+
+start().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/site/auth.js
+++ b/site/auth.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const loginForm = document.getElementById('loginForm');
+  const signupForm = document.getElementById('signupForm');
+
+  async function handle(form, endpoint) {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const data = Object.fromEntries(new FormData(form).entries());
+      try {
+        const res = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data)
+        });
+        const json = await res.json();
+        alert(json.message || json.error);
+      } catch (err) {
+        alert('Network error');
+      }
+    });
+  }
+
+  if (loginForm) handle(loginForm, '/api/login');
+  if (signupForm) handle(signupForm, '/api/register');
+});

--- a/site/blog.html
+++ b/site/blog.html
@@ -26,6 +26,7 @@
   <a href="blog.html" class="mx-2 hover:underline">Blog</a>
   <a href="screenshots.html" class="mx-2 hover:underline">Screenshots</a>
   <a href="contact.html" class="mx-2 hover:underline">Contact</a>
+  <a href="login.html" class="mx-2 hover:underline">Login</a>
 </nav>
   <main id="posts" class="flex-grow container mx-auto px-4 space-y-8" data-reveal>
     <!-- Posts injected by blog.js -->

--- a/site/games.html
+++ b/site/games.html
@@ -26,6 +26,7 @@
   <a href="blog.html" class="mx-2 hover:underline">Blog</a>
   <a href="screenshots.html" class="mx-2 hover:underline">Screenshots</a>
   <a href="contact.html" class="mx-2 hover:underline">Contact</a>
+  <a href="login.html" class="mx-2 hover:underline">Login</a>
 </nav>
 <main class="flex-grow container mx-auto px-4" data-reveal>
   <div class="columns-1 sm:columns-2 lg:columns-3 gap-6 space-y-6">

--- a/site/index.html
+++ b/site/index.html
@@ -38,6 +38,7 @@
   <a href="blog.html" class="mx-2 hover:underline">Blog</a>
   <a href="screenshots.html" class="mx-2 hover:underline">Screenshots</a>
   <a href="contact.html" class="mx-2 hover:underline">Contact</a>
+  <a href="login.html" class="mx-2 hover:underline">Login</a>
 </nav>
 <main class="flex-grow">
   <section class="py-16 bg-gray-900" data-reveal>

--- a/site/login.html
+++ b/site/login.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Contact TentCity Software">
-  <meta property="og:title" content="Contact - TentCity">
-  <meta property="og:description" content="Get in touch with us">
+  <meta name="description" content="Login to TentCity Software">
+  <meta property="og:title" content="Login - TentCity">
+  <meta property="og:description" content="Access your account">
   <meta property="og:image" content="/static/images/TentCityStudio.png">
   <meta name="twitter:card" content="summary_large_image">
-  <title>Contact - TentCity Software</title>
+  <title>Login - TentCity Software</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Montserrat:wght@600&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -18,7 +18,7 @@
 </head>
 <body class="bg-gray-900 min-h-screen flex flex-col">
 <header class="p-6 text-center">
-  <h1 class="text-4xl font-bold text-accent">Contact Us</h1>
+  <h1 class="text-4xl font-bold text-accent">Login</h1>
 </header>
 <nav class="bg-gray-900 text-accent text-center p-4" data-reveal>
   <a href="index.html" class="mx-2 hover:underline">Home</a>
@@ -29,24 +29,19 @@
   <a href="login.html" class="mx-2 hover:underline">Login</a>
 </nav>
 <main class="flex-grow container mx-auto px-4" data-reveal>
-  <div class="bg-gray-800 rounded-lg p-6 shadow max-w-xl mx-auto">
-    <p class="mb-4">Email us at <a href="mailto:hello@tentcity.dev" class="text-accent">hello@tentcity.dev</a></p>
-    <iframe class="w-full rounded mb-4" height="250" loading="lazy" src="https://maps.google.com/maps?q=Vancouver%20BC&output=embed"></iframe>
-    <form name="contact" method="POST" data-netlify="true" class="space-y-4">
-      <input type="hidden" name="form-name" value="contact">
-      <p class="hidden">
-        <label>Don’t fill this out if you're human: <input name="bot-field"></label>
-      </p>
-      <input type="text" name="name" placeholder="Name" class="w-full px-3 py-2 rounded text-black" required>
-      <input type="email" name="email" placeholder="Email" class="w-full px-3 py-2 rounded text-black" required>
-      <textarea name="message" rows="4" placeholder="Message" class="w-full px-3 py-2 rounded text-black" required></textarea>
-      <button type="submit" class="px-5 py-2 rounded-full bg-accent text-black hover:scale-105 transition">Send</button>
+  <div class="bg-gray-800 rounded-lg p-6 shadow max-w-md mx-auto">
+    <form id="loginForm" class="space-y-4">
+      <input type="text" name="username" placeholder="Username" class="w-full px-3 py-2 rounded text-black" required>
+      <input type="password" name="password" placeholder="Password" class="w-full px-3 py-2 rounded text-black" required>
+      <button type="submit" class="px-5 py-2 rounded-full bg-accent text-black hover:scale-105 transition">Login</button>
     </form>
+    <p class="mt-4 text-center">No account? <a href="signup.html" class="text-accent underline">Sign Up</a></p>
   </div>
 </main>
 <footer class="bg-gray-800 text-gray-300 py-4 text-center" data-reveal>
   <a href="index.html" class="text-accent">Back Home</a>
 </footer>
+<script src="auth.js"></script>
 <script src="script.js"></script>
 </body>
 </html>

--- a/site/screenshots.html
+++ b/site/screenshots.html
@@ -26,6 +26,7 @@
   <a href="blog.html" class="mx-2 hover:underline">Blog</a>
   <a href="screenshots.html" class="mx-2 hover:underline">Screenshots</a>
   <a href="contact.html" class="mx-2 hover:underline">Contact</a>
+  <a href="login.html" class="mx-2 hover:underline">Login</a>
 </nav>
 <main class="flex-grow container mx-auto px-4" data-reveal>
   <div class="mb-4 text-center space-x-2">

--- a/site/signup.html
+++ b/site/signup.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Contact TentCity Software">
-  <meta property="og:title" content="Contact - TentCity">
-  <meta property="og:description" content="Get in touch with us">
+  <meta name="description" content="Create a TentCity Software account">
+  <meta property="og:title" content="Sign Up - TentCity">
+  <meta property="og:description" content="Join TentCity Software">
   <meta property="og:image" content="/static/images/TentCityStudio.png">
   <meta name="twitter:card" content="summary_large_image">
-  <title>Contact - TentCity Software</title>
+  <title>Sign Up - TentCity Software</title>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Montserrat:wght@600&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -18,7 +18,7 @@
 </head>
 <body class="bg-gray-900 min-h-screen flex flex-col">
 <header class="p-6 text-center">
-  <h1 class="text-4xl font-bold text-accent">Contact Us</h1>
+  <h1 class="text-4xl font-bold text-accent">Sign Up</h1>
 </header>
 <nav class="bg-gray-900 text-accent text-center p-4" data-reveal>
   <a href="index.html" class="mx-2 hover:underline">Home</a>
@@ -29,24 +29,19 @@
   <a href="login.html" class="mx-2 hover:underline">Login</a>
 </nav>
 <main class="flex-grow container mx-auto px-4" data-reveal>
-  <div class="bg-gray-800 rounded-lg p-6 shadow max-w-xl mx-auto">
-    <p class="mb-4">Email us at <a href="mailto:hello@tentcity.dev" class="text-accent">hello@tentcity.dev</a></p>
-    <iframe class="w-full rounded mb-4" height="250" loading="lazy" src="https://maps.google.com/maps?q=Vancouver%20BC&output=embed"></iframe>
-    <form name="contact" method="POST" data-netlify="true" class="space-y-4">
-      <input type="hidden" name="form-name" value="contact">
-      <p class="hidden">
-        <label>Don’t fill this out if you're human: <input name="bot-field"></label>
-      </p>
-      <input type="text" name="name" placeholder="Name" class="w-full px-3 py-2 rounded text-black" required>
-      <input type="email" name="email" placeholder="Email" class="w-full px-3 py-2 rounded text-black" required>
-      <textarea name="message" rows="4" placeholder="Message" class="w-full px-3 py-2 rounded text-black" required></textarea>
-      <button type="submit" class="px-5 py-2 rounded-full bg-accent text-black hover:scale-105 transition">Send</button>
+  <div class="bg-gray-800 rounded-lg p-6 shadow max-w-md mx-auto">
+    <form id="signupForm" class="space-y-4">
+      <input type="text" name="username" placeholder="Username" class="w-full px-3 py-2 rounded text-black" required>
+      <input type="password" name="password" placeholder="Password" class="w-full px-3 py-2 rounded text-black" required>
+      <button type="submit" class="px-5 py-2 rounded-full bg-accent text-black hover:scale-105 transition">Sign Up</button>
     </form>
+    <p class="mt-4 text-center">Have an account? <a href="login.html" class="text-accent underline">Login</a></p>
   </div>
 </main>
 <footer class="bg-gray-800 text-gray-300 py-4 text-center" data-reveal>
   <a href="index.html" class="text-accent">Back Home</a>
 </footer>
+<script src="auth.js"></script>
 <script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add basic Express server for MongoDB-backed login
- wire up login and signup pages with JS helpers
- document how to run the auth server
- expose MONGODB_URI in `.env.example`
- link login page from navigation

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6842b5f5046c832b8196933c3b0723e8